### PR TITLE
[#323] Improvement: Enable passing credentials for Browserstack via environmental variables for better use in CI/CD

### DIFF
--- a/src/main/java/com/xceptance/neodymium/common/browser/BrowserRunnerHelper.java
+++ b/src/main/java/com/xceptance/neodymium/common/browser/BrowserRunnerHelper.java
@@ -183,13 +183,15 @@ public final class BrowserRunnerHelper
      * 
      * @param config
      *            {@link BrowserConfiguration} that describes the desired browser instance
+     * @param testClassInstance
+     *            {@link String} name of the test to display on test environment
      * @return {@link WebDriverStateContainer} the instance of the browser described in {@link BrowserConfiguration} and
      *         in {@link NeodymiumConfiguration}
      * @throws MalformedURLException
      *             if <a href="https://github.com/Xceptance/neodymium-library/wiki/Selenium-grid">Selenium grid</a> is
      *             used and the given grid URL is invalid
      */
-    public static WebDriverStateContainer createWebDriverStateContainer(final BrowserConfiguration config, final Object testClassInstance)
+    public static WebDriverStateContainer createWebDriverStateContainer(final BrowserConfiguration config, final String testClassInstance)
         throws MalformedURLException
     {
         final MutableCapabilities capabilities = config.getCapabilities();
@@ -404,7 +406,7 @@ public final class BrowserRunnerHelper
             config.getGridProperties().put("userName", testEnvironmentProperties.getUsername());
             config.getGridProperties().put("accessKey", testEnvironmentProperties.getPassword());
             final String buildId = StringUtils.isBlank(System.getenv("BUILD_NUMBER")) ? "local run" : System.getenv("BUILD_NUMBER");
-            config.getGridProperties().put("sessionName", testClassInstance instanceof String ? testClassInstance : testClassInstance.getClass().toString());
+            config.getGridProperties().put("sessionName", testClassInstance);
             config.getGridProperties().put("buildName", "Test Automation");
             config.getGridProperties().put("buildIdentifier", buildId);
             if (testEnvironmentUrl.contains("browserstack"))

--- a/src/main/java/com/xceptance/neodymium/common/browser/BrowserRunnerHelper.java
+++ b/src/main/java/com/xceptance/neodymium/common/browser/BrowserRunnerHelper.java
@@ -241,7 +241,7 @@ public final class BrowserRunnerHelper
                 var remoteDebuggingPort = PortProber.findFreePort();
                 Neodymium.setRemoteDebuggingPort(remoteDebuggingPort);
                 options.addArguments("--remote-debugging-port=" + remoteDebuggingPort);
-                
+
                 if (config.getArguments() != null && config.getArguments().size() > 0)
                 {
                     options.addArguments(config.getArguments());
@@ -361,18 +361,18 @@ public final class BrowserRunnerHelper
 
                 final String driverInPathPath = new ExecutableFinder().find("msedgedriver");
                 final EdgeOptions options = new EdgeOptions().merge(capabilities);
-                
+
                 if (config.getArguments() != null && config.getArguments().size() > 0)
                 {
                     options.addArguments(config.getArguments());
                 }
-                
+
                 EdgeBuilder edgeBuilder = new EdgeBuilder(config.getDriverArguments());
                 if (StringUtils.isNotBlank(driverInPathPath))
                 {
                     edgeBuilder.usingDriverExecutable(new File(driverInPathPath));
                 }
-                
+
                 wDSC.setWebDriver(new EdgeDriver(edgeBuilder.build(), options));
             }
             else if (safariBrowsers.contains(browserName))
@@ -404,7 +404,7 @@ public final class BrowserRunnerHelper
             config.getGridProperties().put("userName", testEnvironmentProperties.getUsername());
             config.getGridProperties().put("accessKey", testEnvironmentProperties.getPassword());
             final String buildId = StringUtils.isBlank(System.getenv("BUILD_NUMBER")) ? "local run" : System.getenv("BUILD_NUMBER");
-            config.getGridProperties().put("sessionName", testClassInstance.getClass().toString());
+            config.getGridProperties().put("sessionName", testClassInstance instanceof String ? testClassInstance : testClassInstance.getClass().toString());
             config.getGridProperties().put("buildName", "Test Automation");
             config.getGridProperties().put("buildIdentifier", buildId);
             if (testEnvironmentUrl.contains("browserstack"))

--- a/src/main/java/com/xceptance/neodymium/common/browser/configuration/TestEnvironment.java
+++ b/src/main/java/com/xceptance/neodymium/common/browser/configuration/TestEnvironment.java
@@ -28,7 +28,15 @@ public class TestEnvironment
     {
         url = properties.getProperty(baseKey + ".url");
         username = properties.getProperty(baseKey + ".username");
+        if (StringUtils.isBlank(username))
+        {
+            username = System.getenv("BROWSERSTACK_USERNAME");
+        }
         password = properties.getProperty(baseKey + ".password");
+        if (StringUtils.isBlank(password))
+        {
+            password = System.getenv("BROWSERSTACK_PASSWORD");
+        }
         optionsTag = properties.getProperty(baseKey + ".optionsTag");
         useProxy = Boolean.valueOf(properties.getProperty(baseKey + ".proxy"));
         if (useProxy)


### PR DESCRIPTION
Enabled reading of BROWSERSTACK_USERNAME and BROWSERSTACK_PASSWORD properties in case no value for test environment credentials were found in properties