### PR TITLE
400.filter browser via property

### DIFF
--- a/src/main/java/com/xceptance/neodymium/common/browser/BrowserData.java
+++ b/src/main/java/com/xceptance/neodymium/common/browser/BrowserData.java
@@ -1,5 +1,14 @@
 package com.xceptance.neodymium.common.browser;
 
+import com.xceptance.neodymium.common.Data;
+import com.xceptance.neodymium.junit5.NeodymiumTest;
+import com.xceptance.neodymium.util.Neodymium;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Repeatable;
 import java.lang.reflect.AnnotatedElement;
@@ -13,16 +22,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.commons.lang3.StringUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-
-import com.xceptance.neodymium.common.Data;
-import com.xceptance.neodymium.junit5.NeodymiumTest;
-import com.xceptance.neodymium.util.Neodymium;
-
 public class BrowserData extends Data
 {
     private List<String> classBrowsers;
@@ -34,8 +33,6 @@ public class BrowserData extends Data
     private List<RandomBrowsers> classRandomBrowsersAnnotation;
 
     private Class<?> testClass;
-
-    private static final String SYSTEM_PROPERTY_BROWSERDEFINITION = "browserdefinition";
 
     public BrowserData(Class<?> testClass)
     {
@@ -133,17 +130,15 @@ public class BrowserData extends Data
             System.setProperty("webdriver.edge.driver", edgeDriverPath);
         }
 
-        // TODO: do we need a possibility to define browser tags globaly via system var? Is this opportunity documented?
-
         // get test specific browser definitions (aka browser tag see browser.properties)
         // could be one value or comma separated list of values
-        String browserDefinitionsProperty = System.getProperty(SYSTEM_PROPERTY_BROWSERDEFINITION, "");
-        browserDefinitionsProperty = browserDefinitionsProperty.replaceAll("\\s", "");
+        String browserFilter = Neodymium.configuration().getBrowserFilter();
+        browserFilter = browserFilter.replaceAll("\\s", "");
 
         // parse test specific browser definitions
-        if (!StringUtils.isEmpty(browserDefinitionsProperty))
+        if (!StringUtils.isEmpty(browserFilter))
         {
-            systemBrowserFilter = Arrays.asList(browserDefinitionsProperty.split(","));
+            systemBrowserFilter = Arrays.asList(browserFilter.split(","));
         }
     }
 

--- a/src/main/java/com/xceptance/neodymium/common/browser/BrowserData.java
+++ b/src/main/java/com/xceptance/neodymium/common/browser/BrowserData.java
@@ -130,6 +130,7 @@ public class BrowserData extends Data
             System.setProperty("webdriver.edge.driver", edgeDriverPath);
         }
 
+        // already filter the list of browsers here to speed up the actual filter later
         // get test specific browser definitions (aka browser tag see browser.properties)
         // could be one value or comma separated list of values
         String browserFilter = Neodymium.configuration().getBrowserFilter();

--- a/src/main/java/com/xceptance/neodymium/junit5/filtering/FilterTestMethodCallback.java
+++ b/src/main/java/com/xceptance/neodymium/junit5/filtering/FilterTestMethodCallback.java
@@ -1,24 +1,28 @@
 package com.xceptance.neodymium.junit5.filtering;
 
-import java.util.regex.Pattern;
-
+import com.xceptance.neodymium.util.Neodymium;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-import com.xceptance.neodymium.util.Neodymium;
+import java.util.List;
+import java.util.regex.Pattern;
 
 public class FilterTestMethodCallback implements ExecutionCondition
 {
     private String testExecutionRegex = Neodymium.configuration().getTestNameFilter();
 
+    private List<String> browserFilter = Neodymium.getBrowserFilter();
+
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context)
     {
+        String fullMethodName = context.getTestClass().get() + "#" + context.getDisplayName();
+
+        // filter testname
         if (StringUtils.isNotEmpty(testExecutionRegex))
         {
-            String fullMethodName = context.getTestClass().get() + "#" + context.getDisplayName();
             if (!Pattern.compile(testExecutionRegex)
                         .matcher(fullMethodName)
                         .find())
@@ -26,7 +30,16 @@ public class FilterTestMethodCallback implements ExecutionCondition
                 return ConditionEvaluationResult.disabled("not matching the test name filter " + testExecutionRegex);
             }
         }
-        return ConditionEvaluationResult.enabled("");
 
+        // filter browser
+        if (!browserFilter.isEmpty())
+        {
+            if (browserFilter.stream().noneMatch(fullMethodName::contains))
+            {
+                return ConditionEvaluationResult.disabled("no browser contained in the browser filter");
+            }
+        }
+
+        return ConditionEvaluationResult.enabled("");
     }
 }

--- a/src/main/java/com/xceptance/neodymium/util/Neodymium.java
+++ b/src/main/java/com/xceptance/neodymium/util/Neodymium.java
@@ -1,21 +1,5 @@
 package com.xceptance.neodymium.util;
 
-
-
-import org.aeonbits.owner.ConfigFactory;
-import org.openqa.selenium.By;
-import org.openqa.selenium.Dimension;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.remote.RemoteWebDriver;
-
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Random;
-import java.util.WeakHashMap;
-
 import com.browserup.bup.BrowserUpProxy;
 import com.codeborne.selenide.AssertionMode;
 import com.codeborne.selenide.Configuration;
@@ -23,6 +7,21 @@ import com.codeborne.selenide.Selenide;
 import com.xceptance.neodymium.common.TestStepListener;
 import com.xceptance.neodymium.common.browser.WebDriverStateContainer;
 import com.xceptance.neodymium.common.testdata.TestData;
+import org.aeonbits.owner.ConfigFactory;
+import org.apache.commons.lang3.StringUtils;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Dimension;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.WeakHashMap;
 
 
 /**
@@ -43,6 +42,8 @@ public class Neodymium
     
     // keep our current browser name
     private String browserName;
+
+    private static List<String> browserFilter = generateBrowserFilter();
     
     // keep our current remote debugging port
     private int remoteDebuggingPort;
@@ -75,6 +76,26 @@ public class Neodymium
         }
         configuration = ConfigFactory.create(NeodymiumConfiguration.class, System.getProperties(), System.getenv());
         localization = NeodymiumLocalization.build(configuration.localizationFile());
+    }
+
+    private static List<String> generateBrowserFilter()
+    {
+        // get test specific browser definitions (aka browser tag see browser.properties)
+        // could be one value or comma separated list of values
+        String filter = Neodymium.configuration().getBrowserFilter();
+        filter = filter.replaceAll("\\s", "");
+
+        // parse test specific browser definitions
+        if (!StringUtils.isEmpty(filter))
+        {
+            return Arrays.asList(filter.split(","));
+        }
+        return new ArrayList<String>();
+    }
+
+    public static List<String> getBrowserFilter()
+    {
+        return browserFilter;
     }
 
     /**

--- a/src/main/java/com/xceptance/neodymium/util/NeodymiumConfiguration.java
+++ b/src/main/java/com/xceptance/neodymium/util/NeodymiumConfiguration.java
@@ -1,11 +1,10 @@
 package com.xceptance.neodymium.util;
 
+import com.xceptance.neodymium.junit4.NeodymiumRunner.DescriptionMode;
 import org.aeonbits.owner.Config.LoadPolicy;
 import org.aeonbits.owner.Config.LoadType;
 import org.aeonbits.owner.Config.Sources;
 import org.aeonbits.owner.Mutable;
-
-import com.xceptance.neodymium.junit4.NeodymiumRunner.DescriptionMode;
 
 @LoadPolicy(LoadType.MERGE)
 @Sources(
@@ -277,6 +276,10 @@ public interface NeodymiumConfiguration extends Mutable
     @Key("neodymium.webDriver.maxReuse")
     @DefaultValue("-1")
     public int maxWebDriverReuse();
+
+    @Key("neodymium.webDriver.browserFilter")
+    @DefaultValue("")
+    public String getBrowserFilter();
 
     @Key("neodymium.webDriver.startNewBrowserForSetUp")
     @DefaultValue("true")


### PR DESCRIPTION
Extended the browser filter to be set via properties.

Added documentation in branch `400.filter.browser.property` in the wiki.